### PR TITLE
Added failsafes to avoid 500 Internal Server Error

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -41,6 +41,7 @@
         "@types/express-session": "^1.17.4",
         "@types/jest": "27.0.2",
         "@types/node": "^16.0.0",
+        "@types/passport-github2": "^1.2.5",
         "@types/supertest": "^2.0.11",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
@@ -2154,11 +2155,51 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.24.tgz",
       "integrity": "sha512-Ezv33Rl4mIi6YdSHfIRNBd4Q9kUe5okiaw/ikvJiJDmuQZNW5kfdg7+oQPF8NO6sTcr3woIpj3jANzTXdvEZXA=="
     },
+    "node_modules/@types/oauth": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
+      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "node_modules/@types/passport": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.7.tgz",
+      "integrity": "sha512-JtswU8N3kxBYgo+n9of7C97YQBT+AYPP2aBfNGTzABqPAZnK/WOAaKfh3XesUYMZRrXFuoPc2Hv0/G/nQFveHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-github2": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/passport-github2/-/passport-github2-1.2.5.tgz",
+      "integrity": "sha512-+WLyrd8JPsCxroK34EjegR0j3FMxp6wqB9cw/sRCFkWT9qic1dymAn021gr336EpyjzdhjUd2KKrqyxvdFSvOA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
+      }
+    },
+    "node_modules/@types/passport-oauth2": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.11.tgz",
+      "integrity": "sha512-KUNwmGhe/3xPbjkzkPwwcPmyFwfyiSgtV1qOrPBLaU4i4q9GSCdAOyCbkFG0gUxAyEmYwqo9OAF/rjPjJ6ImdA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/oauth": "*",
+        "@types/passport": "*"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.4.4",
@@ -11442,11 +11483,51 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.24.tgz",
       "integrity": "sha512-Ezv33Rl4mIi6YdSHfIRNBd4Q9kUe5okiaw/ikvJiJDmuQZNW5kfdg7+oQPF8NO6sTcr3woIpj3jANzTXdvEZXA=="
     },
+    "@types/oauth": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
+      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/passport": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.7.tgz",
+      "integrity": "sha512-JtswU8N3kxBYgo+n9of7C97YQBT+AYPP2aBfNGTzABqPAZnK/WOAaKfh3XesUYMZRrXFuoPc2Hv0/G/nQFveHw==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/passport-github2": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/passport-github2/-/passport-github2-1.2.5.tgz",
+      "integrity": "sha512-+WLyrd8JPsCxroK34EjegR0j3FMxp6wqB9cw/sRCFkWT9qic1dymAn021gr336EpyjzdhjUd2KKrqyxvdFSvOA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
+      }
+    },
+    "@types/passport-oauth2": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.11.tgz",
+      "integrity": "sha512-KUNwmGhe/3xPbjkzkPwwcPmyFwfyiSgtV1qOrPBLaU4i4q9GSCdAOyCbkFG0gUxAyEmYwqo9OAF/rjPjJ6ImdA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/oauth": "*",
+        "@types/passport": "*"
+      }
     },
     "@types/prettier": {
       "version": "2.4.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -53,6 +53,7 @@
     "@types/express-session": "^1.17.4",
     "@types/jest": "27.0.2",
     "@types/node": "^16.0.0",
+    "@types/passport-github2": "^1.2.5",
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/backend/src/api/matches/dto/update-match.dto.ts
+++ b/backend/src/api/matches/dto/update-match.dto.ts
@@ -1,9 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsInt, IsOptional } from 'class-validator';
+import { IsArray, IsInt, IsNotEmpty, IsOptional } from 'class-validator';
 import User from 'src/api/users/entities/user.entity';
 
 export class UpdateMatchDTO {
+  @ApiProperty({ required: false })
   @IsArray()
+  @IsNotEmpty()
   @IsOptional()
   readonly players: User[];
 
@@ -13,7 +15,9 @@ export class UpdateMatchDTO {
   // @ApiProperty({ required: false })
   // readonly playerTwo: User;
 
+  @ApiProperty({ required: false })
   @IsArray()
+  @IsNotEmpty()
   @IsOptional()
   readonly score: number[];
 
@@ -25,6 +29,8 @@ export class UpdateMatchDTO {
   // @IsInt()
   // readonly scorePlayerTwo: number;
 
+  @ApiProperty({ required: false })
+  @IsNotEmpty()
   @IsOptional()
   readonly winner: User;
 }

--- a/backend/src/api/matches/matches.controller.ts
+++ b/backend/src/api/matches/matches.controller.ts
@@ -25,51 +25,51 @@ export class MatchesController {
     return await this.matchesService.getAllMatches();
   }
 
-  @Get(':id')
+  @Get(':matchID')
   async getMatchByID(
-    @Param('id', ParseIntPipe) matchID: number,
+    @Param('matchID', ParseIntPipe) matchID: number,
   ): Promise<Match> {
     return await this.matchesService.getMatchByID(matchID);
   }
 
-  @Get(':id/playerOne')
+  @Get(':matchID/playerOne')
   async getMatchPlayerOne(
-    @Param('id', ParseIntPipe) matchID: number,
+    @Param('matchID', ParseIntPipe) matchID: number,
   ): Promise<User> {
     return await this.matchesService.getMatchPlayerOne(matchID);
   }
 
-  @Get(':id/playerTwo')
+  @Get(':matchID/playerTwo')
   async getMatchPlayerTwo(
-    @Param('id', ParseIntPipe) matchID: number,
+    @Param('matchID', ParseIntPipe) matchID: number,
   ): Promise<User> {
     return await this.matchesService.getMatchPlayerTwo(matchID);
   }
 
-  @Get(':id/score')
+  @Get(':matchID/score')
   async getMatchScore(
-    @Param('id', ParseIntPipe) matchID: number,
+    @Param('matchID', ParseIntPipe) matchID: number,
   ): Promise<number[]> {
     return await this.matchesService.getMatchScore(matchID);
   }
 
-  @Get(':id/scorePlayerOne')
+  @Get(':matchID/scorePlayerOne')
   async getMatchScorePlayerOne(
-    @Param('id', ParseIntPipe) matchID: number,
+    @Param('matchID', ParseIntPipe) matchID: number,
   ): Promise<number> {
     return await this.matchesService.getMatchScorePlayerOne(matchID);
   }
 
-  @Get(':id/scorePlayerTwo')
+  @Get(':matchID/scorePlayerTwo')
   async getMatchScorePlayerTwo(
-    @Param('id', ParseIntPipe) matchID: number,
+    @Param('matchID', ParseIntPipe) matchID: number,
   ): Promise<number> {
     return await this.matchesService.getMatchScorePlayerTwo(matchID);
   }
 
-  @Get(':id/winner')
+  @Get(':matchID/winner')
   async getMatchWinner(
-    @Param('id', ParseIntPipe) matchID: number,
+    @Param('matchID', ParseIntPipe) matchID: number,
   ): Promise<User> {
     return await this.matchesService.getMatchWinner(matchID);
   }
@@ -79,16 +79,18 @@ export class MatchesController {
     return await this.matchesService.createMatch(match);
   }
 
-  @Patch(':id')
+  @Patch(':matchID')
   async updateMatch(
-    @Param('id', ParseIntPipe) matchID: number,
+    @Param('matchID', ParseIntPipe) matchID: number,
     @Body() updatedMatch: UpdateMatchDTO,
   ): Promise<Match> {
     return await this.matchesService.updateMatch(matchID, updatedMatch);
   }
 
-  @Delete(':id')
-  async deleteMatch(@Param('id', ParseIntPipe) matchID: number): Promise<void> {
+  @Delete(':matchID')
+  async deleteMatch(
+    @Param('matchID', ParseIntPipe) matchID: number,
+  ): Promise<void> {
     return await this.matchesService.deleteMatch(matchID);
   }
 }

--- a/backend/src/api/messages/dto/update-message.dto.ts
+++ b/backend/src/api/messages/dto/update-message.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional } from 'class-validator';
+import Channel from 'src/api/channels/entities/channel.entity';
+import User from 'src/api/users/entities/user.entity';
+
+export class UpdateMessageDTO {
+  @ApiProperty({ required: false })
+  @IsNotEmpty()
+  @IsOptional()
+  readonly author: User;
+
+  @ApiProperty({ required: false })
+  @IsNotEmpty()
+  @IsOptional()
+  readonly channel: Channel;
+
+  @ApiProperty({ required: false })
+  @IsNotEmpty()
+  @IsOptional()
+  readonly data: string;
+}

--- a/backend/src/api/messages/entities/message.entity.ts
+++ b/backend/src/api/messages/entities/message.entity.ts
@@ -13,7 +13,7 @@ class Message {
   @PrimaryGeneratedColumn()
   public id: number;
 
-  @ManyToOne((type) => User, (user) => user.id)
+  @ManyToOne((type) => User, (user) => user.messages)
   public author: User;
 
   @ManyToOne((type) => Channel, (channel) => channel.messages, {

--- a/backend/src/api/messages/messages.controller.ts
+++ b/backend/src/api/messages/messages.controller.ts
@@ -37,30 +37,30 @@ export class MessagesController {
     return await this.messagesService.getMessagesByFilter(filter);
   }
 
-  @Get(':id')
+  @Get(':messageID')
   async getMessageByID(
-    @Param('id', ParseIntPipe) messageID: number,
+    @Param('messageID', ParseIntPipe) messageID: number,
   ): Promise<Message> {
     return await this.messagesService.getMessageByID(messageID);
   }
 
-  @Get(':id/author')
+  @Get(':messageID/author')
   async getMessageAuthor(
-    @Param('id', ParseIntPipe) messageID: number,
+    @Param('messageID', ParseIntPipe) messageID: number,
   ): Promise<User> {
     return await this.messagesService.getMessageAuthor(messageID);
   }
 
-  @Get(':id/channel')
+  @Get(':messageID/channel')
   async getMessageChannel(
-    @Param('id', ParseIntPipe) messageID: number,
+    @Param('messageID', ParseIntPipe) messageID: number,
   ): Promise<Channel> {
     return await this.messagesService.getMessageChannel(messageID);
   }
 
-  @Get(':id/data')
+  @Get(':messageID/data')
   async getMessageData(
-    @Param('id', ParseIntPipe) messageID: number,
+    @Param('messageID', ParseIntPipe) messageID: number,
   ): Promise<string> {
     return await this.messagesService.getMessageData(messageID);
   }
@@ -70,8 +70,8 @@ export class MessagesController {
     return await this.messagesService.createMessage(message);
   }
 
-  @Delete(':id')
-  async deleteMessage(@Param('id') messageID: number) {
+  @Delete(':messageID')
+  async deleteMessage(@Param('messageID') messageID: number) {
     return await this.messagesService.deleteMessage(messageID);
   }
 }

--- a/backend/src/api/messages/messages.controller.ts
+++ b/backend/src/api/messages/messages.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
   Query,
 } from '@nestjs/common';
@@ -16,6 +17,7 @@ import { Utils } from 'src/utils/utils.provider';
 import Message from './entities/message.entity';
 import User from 'src/api/users/entities/user.entity';
 import Channel from 'src/api/channels/entities/channel.entity';
+import { UpdateMessageDTO } from './dto/update-message.dto';
 
 @Controller('messages')
 @ApiTags('messages')
@@ -68,6 +70,14 @@ export class MessagesController {
   @Post()
   async createMessage(@Body() message: CreateMessageDTO): Promise<Message> {
     return await this.messagesService.createMessage(message);
+  }
+
+  @Patch(':messageID')
+  async updateMessage(
+    @Param('messageID', ParseIntPipe) messageID: number,
+    @Body() updatedMessage: UpdateMessageDTO,
+  ): Promise<Message> {
+    return await this.messagesService.updateMessage(messageID, updatedMessage);
   }
 
   @Delete(':messageID')

--- a/backend/src/api/messages/messages.module.ts
+++ b/backend/src/api/messages/messages.module.ts
@@ -4,9 +4,11 @@ import { MessagesController } from './messages.controller';
 import { MessagesService } from './messages.service';
 import { Utils } from 'src/utils/utils.provider';
 import Message from './entities/message.entity';
+import Channel from 'src/api/channels/entities/channel.entity';
+import User from 'src/api/users/entities/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Message])],
+  imports: [TypeOrmModule.forFeature([Message, User, Channel])],
   controllers: [MessagesController],
   providers: [MessagesService, Utils],
 })

--- a/backend/src/api/stats/dto/create-stats.dto.ts
+++ b/backend/src/api/stats/dto/create-stats.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDecimal, IsDefined, IsInt, IsNotEmpty } from 'class-validator';
-import { Double } from 'typeorm';
-import User from '../../users/entities/user.entity';
+import User from 'src/api/users/entities/user.entity';
 
 export class CreateStatsDTO {
   @IsNotEmpty()

--- a/backend/src/api/stats/dto/update-stats.dto.ts
+++ b/backend/src/api/stats/dto/update-stats.dto.ts
@@ -1,24 +1,28 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDecimal, IsInt, IsNumber, IsOptional } from 'class-validator';
+import { IsDecimal, IsInt, IsNotEmpty, IsOptional } from 'class-validator';
 
 export class UpdateStatsDTO {
   @ApiProperty({ required: false })
   @IsInt()
+  @IsNotEmpty()
   @IsOptional()
   readonly played: number;
 
   @ApiProperty({ required: false })
   @IsInt()
+  @IsNotEmpty()
   @IsOptional()
   readonly win: number;
 
   @ApiProperty({ required: false })
   @IsInt()
+  @IsNotEmpty()
   @IsOptional()
   readonly lose: number;
 
   @ApiProperty({ required: false, type: 'decimal' })
   @IsDecimal()
+  @IsNotEmpty()
   @IsOptional()
   readonly ratio: number;
 }

--- a/backend/src/api/stats/stats.controller.ts
+++ b/backend/src/api/stats/stats.controller.ts
@@ -21,44 +21,44 @@ export class StatsController {
     return await this.statsService.getAllStats();
   }
 
-  @Get(':id')
+  @Get(':statsID')
   async getStatsByID(
-    @Param('id', ParseIntPipe) statsID: number,
+    @Param('statsID', ParseIntPipe) statsID: number,
   ): Promise<Stats> {
     return await this.statsService.getStatsByID(statsID);
   }
 
-  @Get(':id/played')
+  @Get(':statsID/played')
   async getStatPlayed(
-    @Param('id', ParseIntPipe) statsID: number,
+    @Param('statsID', ParseIntPipe) statsID: number,
   ): Promise<number> {
     return await this.statsService.getStatPlayed(statsID);
   }
 
-  @Get(':id/win')
+  @Get(':statsID/win')
   async getStatWin(
-    @Param('id', ParseIntPipe) statsID: number,
+    @Param('statsID', ParseIntPipe) statsID: number,
   ): Promise<number> {
     return await this.statsService.getStatWin(statsID);
   }
 
-  @Get(':id/lose')
+  @Get(':statsID/lose')
   async getStatLose(
-    @Param('id', ParseIntPipe) statsID: number,
+    @Param('statsID', ParseIntPipe) statsID: number,
   ): Promise<number> {
     return await this.statsService.getStatLose(statsID);
   }
 
-  @Get(':id/ratio')
+  @Get(':statsID/ratio')
   async getStatRatio(
-    @Param('id', ParseIntPipe) statsID: number,
+    @Param('statsID', ParseIntPipe) statsID: number,
   ): Promise<number> {
     return await this.statsService.getStatRatio(statsID);
   }
 
-  @Patch(':id')
+  @Patch(':statsID')
   async updateStats(
-    @Param('id', ParseIntPipe) statsID: number,
+    @Param('statsID', ParseIntPipe) statsID: number,
     @Body() updatedStats: UpdateStatsDTO,
   ): Promise<Stats> {
     return await this.statsService.updateStats(statsID, updatedStats);

--- a/backend/src/api/stats/stats.service.ts
+++ b/backend/src/api/stats/stats.service.ts
@@ -69,13 +69,12 @@ export class StatsService {
     statsID: number,
     updatedStats: UpdateStatsDTO,
   ): Promise<Stats> {
-    const stats = await this.statsRepository.findOne({
-      where: { id: statsID },
-    });
-    if (!stats) throw new NotFoundException('Stats not found (id incorrect)');
-    else {
+    try {
+      const stats = await this.getStatsByID(statsID);
       await this.statsRepository.update(statsID, updatedStats);
       return this.getStatsByID(statsID);
+    } catch (error) {
+      throw error;
     }
   }
 }

--- a/backend/src/api/stats/stats.service.ts
+++ b/backend/src/api/stats/stats.service.ts
@@ -25,7 +25,7 @@ export class StatsService {
       where: { id: statsID },
       relations: ['user'],
     });
-    if (!stats) throw new NotFoundException('Stats not found (id not correct)');
+    if (!stats) throw new NotFoundException('Stats not found (id incorrect)');
     return stats;
   }
 

--- a/backend/src/api/users/users.controller.ts
+++ b/backend/src/api/users/users.controller.ts
@@ -61,9 +61,9 @@ export class UsersController {
   @Patch(':userID')
   async updateUser(
     @Param('userID', ParseIntPipe) userID: number,
-    @Body() createUserDTO: UpdateUserDTO,
+    @Body() updatedUser: UpdateUserDTO,
   ): Promise<User> {
-    return await this.usersService.updateUser(userID, createUserDTO);
+    return await this.usersService.updateUser(userID, updatedUser);
   }
 
   @Delete(':userID')

--- a/backend/src/api/users/users.service.ts
+++ b/backend/src/api/users/users.service.ts
@@ -34,6 +34,7 @@ export class UsersService {
         'stats',
         // Below: For DEBUG, may remove later
         'messages',
+        'messages.channel',
         'playedMatches',
         'winMatches',
         'ownerChannels',
@@ -51,6 +52,7 @@ export class UsersService {
     relations: string[] = [
       'stats',
       'messages',
+      'messages.channel',
       'playedMatches',
       'winMatches',
       'ownerChannels',

--- a/backend/src/api/users/users.service.ts
+++ b/backend/src/api/users/users.service.ts
@@ -100,7 +100,10 @@ export class UsersService {
     const count = await this.usersRepository.count({
       where: { username: user.username },
     });
-    if (count > 0) throw new ForbiddenException('Username must be unique');
+    if (count > 0)
+      throw new ForbiddenException(
+        "Can't create new User (username must be unique)",
+      );
 
     // Creating and new user and it's stats
     const newUser = this.usersRepository.create(user);
@@ -115,7 +118,7 @@ export class UsersService {
     const user = await this.usersRepository.findOne({
       where: { id: userID },
     });
-    if (!user) return this.createUser(updatedUser);
+    if (!user) throw new NotFoundException('User not found (id incorrect)');
     else await this.usersRepository.update(userID, updatedUser);
 
     return await this.getUserByID(userID);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -30,7 +30,10 @@ async function bootstrap() {
     .setVersion('1.0')
     .build();
   const document = SwaggerModule.createDocument(api, config);
-  SwaggerModule.setup('/', api, document);
+  SwaggerModule.setup('/', api, document, {
+    customCss: '.swagger-ui .topbar { display: none }',
+    customSiteTitle: 'API Definition',
+  });
 
   // Starting up API service
   const configService = api.get(ConfigService);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
 volumes:
   postgres:
-  pgadmin:
+  # pgadmin:
   # dbeaver:
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgres:
-    container_name: postgres-transcendence
+    container_name: postgres-transcendence-${USER}
     image: postgres:14
     environment:
       - POSTGRES_HOST=${POSTGRES_HOST}

--- a/requests.rest
+++ b/requests.rest
@@ -14,10 +14,6 @@ GET http://{{host}}/users
 
 ###
 
-GET http://{{host}}/users/1
-
-###
-
 POST http://{{host}}/users
 Content-Type: {{contentType}}
 
@@ -48,10 +44,6 @@ GET http://{{host}}/stats
 
 ###
 
-GET http://{{host}}/stats/1
-
-###
-
 PATCH http://{{host}}/stats/1
 Content-Type: {{contentType}}
 
@@ -68,18 +60,32 @@ Content-Type: {{contentType}}
 // Messages requests
 // #################
 
+GET http://{{host}}/messages
+
+###
+
 POST http://{{host}}/messages
 Content-Type: {{contentType}}
 
 {
     "author": {"id": 1},
-    "channel": {"id": 1},
+    "channel": {"id": 3},
     "data": "Bouh!"
 }
 
 ###
 
-DELETE http://{{host}}/messages/1
+PATCH http://{{host}}/messages/5
+Content-Type: {{contentType}}
+
+{
+    "author": {"id": 3},
+    "data": "Bouh Me!!"
+}
+
+###
+
+DELETE http://{{host}}/messages/4
 
 ###
 
@@ -91,7 +97,7 @@ POST http://{{host}}/channels
 Content-Type: {{contentType}}
 
 {
-    "name": "Channel1",
+    "name": "Channel2",
     "owner": {"id": 1},
     "admins": [{"id": 1}, {"id": 2}],
     "members": [{"id": 1}, {"id": 3}, {"id": 4}],

--- a/requests.rest
+++ b/requests.rest
@@ -31,8 +31,7 @@ PATCH http://{{host}}/users/1
 Content-Type: {{contentType}}
 
 {
-    "username": "Updated",
-    "socketID": ""
+    "username": "Updated"
 }
 
 ###
@@ -73,7 +72,7 @@ POST http://{{host}}/messages
 Content-Type: {{contentType}}
 
 {
-    "author": 1,
+    "author": {"id": 1},
     "channel": {"id": 1},
     "data": "Bouh!"
 }

--- a/requests.rest
+++ b/requests.rest
@@ -69,23 +69,23 @@ Content-Type: {{contentType}}
 
 {
     "author": {"id": 1},
-    "channel": {"id": 3},
+    "channel": {"id": 1},
     "data": "Bouh!"
 }
 
 ###
 
-PATCH http://{{host}}/messages/5
+PATCH http://{{host}}/messages/1
 Content-Type: {{contentType}}
 
 {
-    "author": {"id": 3},
+    "author": {"id": 1},
     "data": "Bouh Me!!"
 }
 
 ###
 
-DELETE http://{{host}}/messages/4
+DELETE http://{{host}}/messages/1
 
 ###
 
@@ -97,7 +97,7 @@ POST http://{{host}}/channels
 Content-Type: {{contentType}}
 
 {
-    "name": "Channel2",
+    "name": "Channel1",
     "owner": {"id": 1},
     "admins": [{"id": 1}, {"id": 2}],
     "members": [{"id": 1}, {"id": 3}, {"id": 4}],
@@ -106,7 +106,7 @@ Content-Type: {{contentType}}
 
 ###
 
-DELETE http://{{host}}/channels/6
+DELETE http://{{host}}/channels/1
 
 ###
 
@@ -124,13 +124,13 @@ Content-Type: {{contentType}}
 
 ###
 
-PATCH http://{{host}}/matches/2
+PATCH http://{{host}}/matches/1
 Content-Type: {{contentType}}
 
 {
-    "players": [{"id": 4}, {"id": 5}],
+    "players": [{"id": 3}, {"id": 2}],
     "score": [42, 21],
-    "winner": {"id": 4}
+    "winner": {"id": 3}
 }
 
 ###


### PR DESCRIPTION
Added checks on entities routes to avoid crashes, mostly on entity creation and update. For example, when creating a `Match` / `Channel` / `Message`, if the fields corresponding to a `User` entity does not exists (user was not created and thus does not exists), the API now throws a `403 Forbidden` with an explicit error message (NestJS was throwing an error `500` before).
There may still be `500` crashes on cases I did not expected. If encountered when using the API, please report them so I can fix them ;)
Changed all `id` to `entityID` (`id` to `messageID` / `channelID` for exemple) for better clarity in API definition page
Otherwise, some routes are still missing, updating a `Channel` via PATCH, or a search route for all the entities. That will be my next step to implement them