### PR TITLE
Filter / Search system redone for User and Channels (Important if you fetch these entities!)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 all: up
 
+re: down all
+
 ### Dev environment ###
 # dev: database backend frontend
 

--- a/backend/src/api/channels/channels.controller.ts
+++ b/backend/src/api/channels/channels.controller.ts
@@ -8,15 +8,17 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
   Redirect,
 } from '@nestjs/common';
 import { ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ChannelsService } from './channels.service';
 import { CreateChannelDTO } from './dto/create-channel.dto';
+import { UpdateChannelDTO } from './dto/update-channel.dto';
+import { FilterChannelDTO } from './dto/filter-channel.dto';
 import Channel from './entities/channel.entity';
 import User from 'src/api/users/entities/user.entity';
 import Message from 'src/api/messages/entities/message.entity';
-import { UpdateChannelDTO } from './dto/update-channel.dto';
 
 @Controller('channels')
 @ApiTags('channels')
@@ -26,6 +28,13 @@ export class ChannelsController {
   @Get()
   async getAllChannels(): Promise<Channel[]> {
     return await this.channelsService.getAllChannels();
+  }
+
+  @Get('search')
+  async getChannelsByFilter(
+    @Query() filter: FilterChannelDTO,
+  ): Promise<Channel[]> {
+    return await this.channelsService.getChannelsByFilter(filter);
   }
 
   @Get(':channelID')

--- a/backend/src/api/channels/channels.service.ts
+++ b/backend/src/api/channels/channels.service.ts
@@ -10,6 +10,7 @@ import { UpdateChannelDTO } from './dto/update-channel.dto';
 import User from 'src/api/users/entities/user.entity';
 import Channel from './entities/channel.entity';
 import Message from 'src/api/messages/entities/message.entity';
+import { FilterChannelDTO } from './dto/filter-channel.dto';
 
 @Injectable()
 export class ChannelsService {
@@ -45,6 +46,42 @@ export class ChannelsService {
     if (!channel)
       throw new NotFoundException('Channel not found (id incorrect)');
     return channel;
+  }
+
+  async getChannelsByFilter(filter: FilterChannelDTO): Promise<Channel[]> {
+    const query = this.channelsRepository
+      .createQueryBuilder('channels')
+      .orderBy('channels.id', 'ASC');
+
+    // Search parameters
+    if ('id' in filter) query.andWhere('channels.id = :id', { id: filter.id });
+    if ('name' in filter)
+      query.andWhere('channels.name = :name', {
+        name: filter.name,
+      });
+    if ('isPrivate' in filter)
+      query.andWhere('channels.isPrivate = :isPrivate', {
+        isPrivate: filter.isPrivate,
+      });
+
+    // Fetch field parameters
+    if ('password' in filter) query.addSelect('channels.password');
+    if ('messages' in filter)
+      query.leftJoinAndSelect('channels.messages', 'messages');
+    if ('owner' in filter) query.leftJoinAndSelect('channels.owner', 'owner');
+    if ('admins' in filter)
+      query.leftJoinAndSelect('channels.admins', 'admins');
+    if ('members' in filter)
+      query.leftJoinAndSelect('channels.members', 'members');
+    if ('mutes' in filter) query.leftJoinAndSelect('channels.mutes', 'mutes');
+    if ('bans' in filter) query.leftJoinAndSelect('channels.bans', 'bans');
+    if ('invites' in filter)
+      query.leftJoinAndSelect('channels.invites', 'invites');
+
+    const channels = await query.getMany();
+    if (!channels.length)
+      throw new NotFoundException('Channels not found (filter incorrect)');
+    return channels;
   }
 
   async getChannelName(channelID: number): Promise<string> {

--- a/backend/src/api/channels/dto/create-channel.dto.ts
+++ b/backend/src/api/channels/dto/create-channel.dto.ts
@@ -3,9 +3,7 @@ import {
   IsArray,
   IsBoolean,
   IsDefined,
-  IsInt,
   IsNotEmpty,
-  IsObject,
   IsOptional,
   IsString,
 } from 'class-validator';
@@ -37,16 +35,19 @@ export class CreateChannelDTO {
   @IsDefined()
   readonly members: User[];
 
+  @ApiProperty({ required: false })
   @IsArray()
   @IsNotEmpty()
   @IsOptional()
   readonly mutes?: User[];
 
+  @ApiProperty({ required: false })
   @IsArray()
   @IsNotEmpty()
   @IsOptional()
   readonly bans?: User[];
 
+  @ApiProperty({ required: false })
   @IsArray()
   @IsNotEmpty()
   @IsOptional()

--- a/backend/src/api/channels/dto/filter-channel.dto.ts
+++ b/backend/src/api/channels/dto/filter-channel.dto.ts
@@ -1,0 +1,71 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsEmpty,
+  IsNotEmpty,
+  IsNumberString,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import User from 'src/api/users/entities/user.entity';
+
+export class FilterChannelDTO {
+  // Search parameters
+  @ApiProperty({ required: false })
+  @IsNumberString()
+  @IsNotEmpty()
+  @IsOptional()
+  readonly id: number;
+
+  @ApiProperty({ required: false })
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  readonly name: string;
+
+  @ApiProperty({ required: false })
+  @IsBoolean()
+  @IsOptional()
+  readonly isPrivate?: boolean;
+
+  // Fetch field parameters
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly password?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly messages?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly owner?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly admins?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly members?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly mutes?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly bans?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly invites?: void;
+}

--- a/backend/src/api/channels/entities/channel.entity.ts
+++ b/backend/src/api/channels/entities/channel.entity.ts
@@ -23,7 +23,7 @@ class Channel {
   @Column({ nullable: true, default: false })
   public isPrivate: boolean;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, select: false })
   public password: string;
 
   @OneToMany((type) => Message, (message) => message.channel, {

--- a/backend/src/api/users/dto/filter-user.dto.ts
+++ b/backend/src/api/users/dto/filter-user.dto.ts
@@ -8,6 +8,7 @@ import {
 } from 'class-validator';
 
 export class FilterUserDTO {
+  // Search parameters
   @ApiProperty({ required: false })
   @IsNumberString()
   @IsOptional()
@@ -17,4 +18,25 @@ export class FilterUserDTO {
   @IsString()
   @IsOptional()
   readonly username?: string;
+
+  // Show field parameters
+  @ApiProperty({ required: false })
+  @IsOptional()
+  readonly password?: void;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  readonly studentID?: void;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  readonly githubID?: void;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  readonly socketID?: void;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  readonly avatar?: void;
 }

--- a/backend/src/api/users/dto/filter-user.dto.ts
+++ b/backend/src/api/users/dto/filter-user.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
   IsBoolean,
   IsBooleanString,
+  IsEmpty,
   IsNumberString,
   IsOptional,
   IsString,
@@ -19,24 +20,89 @@ export class FilterUserDTO {
   @IsOptional()
   readonly username?: string;
 
-  // Show field parameters
+  // Fetch field parameters
   @ApiProperty({ required: false })
+  @IsEmpty()
   @IsOptional()
   readonly password?: void;
 
   @ApiProperty({ required: false })
+  @IsEmpty()
   @IsOptional()
   readonly studentID?: void;
 
   @ApiProperty({ required: false })
+  @IsEmpty()
   @IsOptional()
   readonly githubID?: void;
 
   @ApiProperty({ required: false })
+  @IsEmpty()
   @IsOptional()
   readonly socketID?: void;
 
   @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly stats?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
   @IsOptional()
   readonly avatar?: void;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsEmpty()
+  readonly friends?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly friendsInverse?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly playedMatches?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly winMatches?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly messages?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly ownerChannels?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly adminChannels?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly memberChannels?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly muteChannels?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly banChannels?: void;
+
+  @ApiProperty({ required: false })
+  @IsEmpty()
+  @IsOptional()
+  readonly inviteChannels?: void;
 }

--- a/backend/src/api/users/dto/filter-user.dto.ts
+++ b/backend/src/api/users/dto/filter-user.dto.ts
@@ -1,8 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsBoolean,
-  IsBooleanString,
   IsEmpty,
+  IsNotEmpty,
   IsNumberString,
   IsOptional,
   IsString,
@@ -12,11 +11,13 @@ export class FilterUserDTO {
   // Search parameters
   @ApiProperty({ required: false })
   @IsNumberString()
+  @IsNotEmpty()
   @IsOptional()
   readonly id?: number;
 
   @ApiProperty({ required: false })
   @IsString()
+  @IsNotEmpty()
   @IsOptional()
   readonly username?: string;
 

--- a/backend/src/api/users/entities/user.entity.ts
+++ b/backend/src/api/users/entities/user.entity.ts
@@ -31,10 +31,10 @@ class User {
   @Column({ nullable: true, unique: true, select: false })
   public githubID: string;
 
-  @Column({ nullable: true, length: 20 })
+  @Column({ nullable: true, select: false, length: 20 })
   public socketID: string | null;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, select: false })
   public avatar: string;
 
   @OneToOne((type) => Stats, (stats) => stats.user)

--- a/backend/src/api/users/users.service.ts
+++ b/backend/src/api/users/users.service.ts
@@ -85,11 +85,19 @@ export class UsersService {
       .orderBy('id', 'ASC');
 
     if (showPassword) query.addSelect('users.password');
-    if (filter.id) query.andWhere('users.id = :id', { id: filter.id });
-    if (filter.username)
+    // Search parameters
+    if ('id' in filter) query.andWhere('users.id = :id', { id: filter.id });
+    if ('username' in filter)
       query.andWhere('users.username = :username', {
         username: filter.username,
       });
+
+    // Show field parameters
+    if ('password' in filter) query.addSelect('users.password');
+    if ('studentID' in filter) query.addSelect('users.studentID');
+    if ('githubID' in filter) query.addSelect('users.githubID');
+    if ('socketID' in filter) query.addSelect('users.socketID');
+    if ('avatar' in filter) query.addSelect('users.avatar');
 
     const users = await query.getMany();
     if (!users.length)

--- a/backend/src/api/users/users.service.ts
+++ b/backend/src/api/users/users.service.ts
@@ -82,7 +82,7 @@ export class UsersService {
   ): Promise<User[]> {
     const query = this.usersRepository
       .createQueryBuilder('users')
-      .orderBy('id', 'ASC');
+      .orderBy('users.id', 'ASC');
 
     if (showPassword) query.addSelect('users.password');
     // Search parameters
@@ -92,12 +92,35 @@ export class UsersService {
         username: filter.username,
       });
 
-    // Show field parameters
+    // Fetch field parameters
     if ('password' in filter) query.addSelect('users.password');
     if ('studentID' in filter) query.addSelect('users.studentID');
     if ('githubID' in filter) query.addSelect('users.githubID');
     if ('socketID' in filter) query.addSelect('users.socketID');
     if ('avatar' in filter) query.addSelect('users.avatar');
+    if ('stats' in filter) query.leftJoinAndSelect('users.stats', 'stats');
+    if ('friends' in filter)
+      query.leftJoinAndSelect('users.friends', 'friends');
+    if ('friendsInverse' in filter)
+      query.leftJoinAndSelect('users.friendsInverse', 'friendsInverse');
+    if ('playedMatches' in filter)
+      query.leftJoinAndSelect('users.playedMatches', 'playedMatches');
+    if ('winMatches' in filter)
+      query.leftJoinAndSelect('users.winMatches', 'winMatches');
+    if ('messages' in filter)
+      query.leftJoinAndSelect('users.messages', 'messages');
+    if ('ownerChannels' in filter)
+      query.leftJoinAndSelect('users.ownerChannels', 'ownerChannels');
+    if ('adminChannels' in filter)
+      query.leftJoinAndSelect('users.adminChannels', 'adminChannels');
+    if ('memberChannels' in filter)
+      query.leftJoinAndSelect('users.memberChannels', 'memberChannels');
+    if ('muteChannels' in filter)
+      query.leftJoinAndSelect('users.muteChannels', 'muteChannels');
+    if ('banChannels' in filter)
+      query.leftJoinAndSelect('users.banChannels', 'banChannels');
+    if ('inviteChannels' in filter)
+      query.leftJoinAndSelect('users.inviteChannels', 'inviteChannels');
 
     const users = await query.getMany();
     if (!users.length)

--- a/backend/src/api/users/users.service.ts
+++ b/backend/src/api/users/users.service.ts
@@ -30,6 +30,7 @@ export class UsersService {
   async getAllUsers(): Promise<User[]> {
     const users = await this.usersRepository.find({
       order: { id: 'ASC' },
+      select: ['id', 'username', 'avatar', 'studentID', 'githubID', 'socketID'],
       relations: [
         'stats',
         // Below: For DEBUG, may remove later
@@ -70,6 +71,7 @@ export class UsersService {
   ): Promise<User> {
     const user = await this.usersRepository.findOne({
       where: { id: userID },
+      select: ['id', 'username', 'avatar', 'studentID', 'githubID', 'socketID'],
       relations: relations,
     });
     if (!user) throw new NotFoundException('User not found (id incorrect)');
@@ -161,7 +163,7 @@ export class UsersService {
     stats.user = newUser;
     await this.statsRepository.save(stats);
 
-    console.log('User created: ', newUser);
+    console.log('New user created: ', newUser);
     return newUser;
   }
 

--- a/requests.rest
+++ b/requests.rest
@@ -99,7 +99,7 @@ Content-Type: {{contentType}}
     "name": "Channel1",
     "owner": {"id": 1},
     "members": [{"id": 1}],
-    "invites": [{"id": 3}]
+    "invites": [{"id": 2}]
 }
 
 ###


### PR DESCRIPTION
Redid filter system for `User` and `Channel`: implemented a 'boolean' system via a query string to only fetch wanted data, to ease the load of the API. All this is on the `/search` routes. Now, passwords are **NEVER** shown when querying an entity (except with the filter, see below). Check the filter DTOs in the API definition to see the options.

Multiple variables are now `select: false` by default, and **might disappear** from the response of `/users` and `/users/:userID`, so if you rely on those variables, I would suggest to update your code and use the `/search` routes (and it will be faster as you will only fetch what you want)

How all of this work: if you want to fetch users `avatars` for example, you would have done a `GET` request on `/users` before, and for each users do a `user.avatar`. Even if it still works for now, the 'better' and faster to do this is now:
```
GET http://localhost:4000/users/search?avatar
```
This will return an array of User object, with only the fields `id`, `username` and `avatar`, and without all the other fields you don't need (so the API response is a lot faster)

Same thing, if you want the avatar of a specific user, you could use the `id` and `username` search filters:
```
GET http://localhost:4000/users/search?id=1&avatar

OR

GET http://localhost:4000/users/search?username=Ourobore&avatar
```

And of course, you can mix and match the differents options. A few more exemples:
```
You work on the matches, and only need the 'playedMatches' and 'winMatches' fields

GET http://localhost:4000/users/search?playedMatches&winMatches

OR for a specific user (be careful, response data is still an array, but just with one user in it)

GET http://localhost:4000/users/search?id=1&playedMatches&winMatches
GET http://localhost:4000/users/search?username=Ourobore&playedMatches&winMatches
```
Or if you work on the channels (from `User` side)
```
GET http://localhost:4000/users/search?id=1&ownerChannels&adminChannels&memberChannels&muteChannels&banChannels&inviteChannels
```
And so on, and so on: the examples here are **NOT EXHAUSTIVE**. So, once again, **read the the DTOs** and use these routes (`/users/search` and `/channels/search`) if you fetch on these entiies: it will probably be faster and lighter with these routes ;)